### PR TITLE
Improve SHAKEN CP and standards lint structure

### DIFF
--- a/v3/lint/source.go
+++ b/v3/lint/source.go
@@ -38,8 +38,8 @@ const (
 	AppleRootStorePolicy     LintSource = "Apple"
 	Community                LintSource = "Community"
 	EtsiEsi                  LintSource = "ETSI_ESI"
-	ATIS1000080              LintSource = "ATIS-1000080v4"
-	CPv1_3                   LintSource = "CPv1.3"
+	ATIS1000080              LintSource = "ATIS-1000080"
+	UnitedStatesSHAKENCP     LintSource = "United States SHAKEN CP"
 	ShakenPKI                LintSource = "SHAKEN PKI Best Practice"
 )
 
@@ -52,7 +52,7 @@ func (s *LintSource) UnmarshalJSON(data []byte) error {
 	}
 
 	switch LintSource(throwAway) {
-	case RFC5280, RFC5480, RFC5891, CABFBaselineRequirements, CABFEVGuidelines, MozillaRootStorePolicy, AppleRootStorePolicy, Community, EtsiEsi, ATIS1000080, CPv1_3, ShakenPKI:
+	case RFC5280, RFC5480, RFC5891, CABFBaselineRequirements, CABFEVGuidelines, MozillaRootStorePolicy, AppleRootStorePolicy, Community, EtsiEsi, ATIS1000080, UnitedStatesSHAKENCP, ShakenPKI:
 		*s = LintSource(throwAway)
 		return nil
 	default:
@@ -90,8 +90,8 @@ func (s *LintSource) FromString(src string) {
 		*s = EtsiEsi
 	case ATIS1000080:
 		*s = ATIS1000080
-	case CPv1_3:
-		*s = CPv1_3
+	case UnitedStatesSHAKENCP:
+		*s = UnitedStatesSHAKENCP
 	case ShakenPKI:
 		*s = ShakenPKI
 	}

--- a/v3/lints/shaken/info.go
+++ b/v3/lints/shaken/info.go
@@ -1,8 +1,9 @@
 package shaken
 
 var (
-	ATIS1000080_STI_Citation = "ATIS-1000080.v004 / 6.4.1 STI Certificate Requirements"
-	CPv1_3_Citation          = "ToKENs (SHAKEN) Certificate Policy"
-	CPv1_3_Citation_4_9      = "ToKENs (SHAKEN) Certificate Policy / 4.9 Certificate Revocation and Suspension"
+	ATIS1000080v003_STI_Citation = "ATIS-1000080.v003 / 6.4.1 SHAKEN Certificate Requirements"
+	ATIS1000080v004_STI_Citation = "ATIS-1000080.v004 / 6.4.1 STI Certificate Requirements"
+	United_States_SHAKEN_CP_Citation          = "United States SHAKEN Certificate Policy"
+	United_States_SHAKEN_CP_Citation_4_9      = "United States SHAKEN Certificate Policy / 4.9 Certificate Revocation and Suspension"
 	PKI_Citation             = "SHAKEN PKI Best Practice"
 )

--- a/v3/lints/shaken/lint_cp1_3_ambiguous_identifier.go
+++ b/v3/lints/shaken/lint_cp1_3_ambiguous_identifier.go
@@ -14,9 +14,9 @@ func init() {
 	lint.RegisterLint(&lint.Lint{
 		Name:          "e_cp1_3_ambiguous_identifier",
 		Description:   "Names used in the STI certificates shall represent an unambiguous identifier for the SP Subject",
-		Citation:      CPv1_3_Citation,
-		Source:        lint.CPv1_3,
-		EffectiveDate: util.CPv1_3_Leaf_Date,
+		Citation:      United_States_SHAKEN_CP_Citation,
+		Source:        lint.UnitedStatesSHAKENCP,
+		EffectiveDate: util.UnitedStatesSHAKENCP_Leaf_Date,
 		Lint:          NewAmbiguousIdentifiers,
 	})
 }

--- a/v3/lints/shaken/lint_cp1_3_ca_key_usage_crl_sign.go
+++ b/v3/lints/shaken/lint_cp1_3_ca_key_usage_crl_sign.go
@@ -14,9 +14,9 @@ func init() {
 	lint.RegisterLint(&lint.Lint{
 		Name:          "e_cp1_3_ca_key_usage_crl_sign",
 		Description:   caKeyUsageCrlSign_details,
-		Citation:      CPv1_3_Citation_4_9,
-		Source:        lint.CPv1_3,
-		EffectiveDate: util.CPv1_3_Date,
+		Citation:      United_States_SHAKEN_CP_Citation_4_9,
+		Source:        lint.UnitedStatesSHAKENCP,
+		EffectiveDate: util.UnitedStatesSHAKENCP_Date,
 		Lint:          NewCaKeyUsageCrlSign,
 	})
 }

--- a/v3/lints/shaken/lint_cp1_3_ca_subject_rdn_unknown.go
+++ b/v3/lints/shaken/lint_cp1_3_ca_subject_rdn_unknown.go
@@ -12,9 +12,9 @@ func init() {
 	lint.RegisterLint(&lint.Lint{
 		Name:          "w_cp1_3_ca_subject_rdn_unknown",
 		Description:   subjectRdn_details,
-		Citation:      CPv1_3_Citation,
-		Source:        lint.CPv1_3,
-		EffectiveDate: util.CPv1_3_Date,
+		Citation:      United_States_SHAKEN_CP_Citation,
+		Source:        lint.UnitedStatesSHAKENCP,
+		EffectiveDate: util.UnitedStatesSHAKENCP_Date,
 		Lint:          NewCaSubjectRdnUnknown,
 	})
 }

--- a/v3/lints/shaken/lint_cp1_3_subject_email.go
+++ b/v3/lints/shaken/lint_cp1_3_subject_email.go
@@ -12,9 +12,9 @@ func init() {
 	lint.RegisterLint(&lint.Lint{
 		Name:          "w_cp_1_3_subject_email",
 		Description:   "Information that is not verified shall not be included in certificates",
-		Citation:      CPv1_3_Citation,
-		Source:        lint.CPv1_3,
-		EffectiveDate: util.CPv1_3_Leaf_Date,
+		Citation:      United_States_SHAKEN_CP_Citation,
+		Source:        lint.UnitedStatesSHAKENCP,
+		EffectiveDate: util.UnitedStatesSHAKENCP_Leaf_Date,
 		Lint:          NewSubjectEmail,
 	})
 }

--- a/v3/lints/shaken/lint_cp1_3_subject_rdn_unknown.go
+++ b/v3/lints/shaken/lint_cp1_3_subject_rdn_unknown.go
@@ -14,9 +14,9 @@ func init() {
 	lint.RegisterLint(&lint.Lint{
 		Name:          "w_cp1_3_subject_rdn_unknown",
 		Description:   subjectRdn_details,
-		Citation:      CPv1_3_Citation,
-		Source:        lint.CPv1_3,
-		EffectiveDate: util.CPv1_3_Leaf_Date,
+		Citation:      United_States_SHAKEN_CP_Citation,
+		Source:        lint.UnitedStatesSHAKENCP,
+		EffectiveDate: util.UnitedStatesSHAKENCP_Leaf_Date,
 		Lint:          NewSubjectRdnUnknown,
 	})
 }

--- a/v3/lints/shaken/lint_cp1_3_subject_sn.go
+++ b/v3/lints/shaken/lint_cp1_3_subject_sn.go
@@ -16,9 +16,9 @@ func init() {
 	lint.RegisterLint(&lint.Lint{
 		Name:          "e_cp1_3_subject_sn",
 		Description:   "The ‘serialNumber’ attribute shall be included along with the CN",
-		Citation:      CPv1_3_Citation,
-		Source:        lint.CPv1_3,
-		EffectiveDate: util.CPv1_3_Leaf_Date,
+		Citation:      United_States_SHAKEN_CP_Citation,
+		Source:        lint.UnitedStatesSHAKENCP,
+		EffectiveDate: util.UnitedStatesSHAKENCP_Leaf_Date,
 		Lint:          NewSubjectSN,
 	})
 }

--- a/v3/lints/shaken/lint_sti_authority_key_identifier.go
+++ b/v3/lints/shaken/lint_sti_authority_key_identifier.go
@@ -20,9 +20,9 @@ func init() {
 	lint.RegisterLint(&lint.Lint{
 		Name:          "e_sti_authority_key_identifier",
 		Description:   "STI certificates shall contain an Authority Key Identifier extension",
-		Citation:      ATIS1000080_STI_Citation,
+		Citation:      ATIS1000080v003_STI_Citation,
 		Source:        lint.ATIS1000080,
-		EffectiveDate: util.ATIS1000080_v004_Leaf_Date,
+		EffectiveDate: util.ATIS1000080_v003_Leaf_Date,
 		Lint:          NewAuthorityKeyIdentifier,
 	})
 }

--- a/v3/lints/shaken/lint_sti_basic_constraints.go
+++ b/v3/lints/shaken/lint_sti_basic_constraints.go
@@ -19,9 +19,9 @@ func init() {
 	lint.RegisterLint(&lint.Lint{
 		Name:          "e_sti_basic_constraints",
 		Description:   "STI certificates shall contain a Basic Constraints extension marked critical",
-		Citation:      ATIS1000080_STI_Citation,
+		Citation:      ATIS1000080v003_STI_Citation,
 		Source:        lint.ATIS1000080,
-		EffectiveDate: util.ATIS1000080_v004_Date,
+		EffectiveDate: util.ATIS1000080_v003_Date,
 		Lint:          NewBasicConstraints,
 	})
 }

--- a/v3/lints/shaken/lint_sti_ca_authority_key_identifier.go
+++ b/v3/lints/shaken/lint_sti_ca_authority_key_identifier.go
@@ -20,9 +20,9 @@ func init() {
 	lint.RegisterLint(&lint.Lint{
 		Name:          "e_sti_ca_authority_key_identifier",
 		Description:   "STI certificates shall contain an Authority Key Identifier extension",
-		Citation:      ATIS1000080_STI_Citation,
+		Citation:      ATIS1000080v003_STI_Citation,
 		Source:        lint.ATIS1000080,
-		EffectiveDate: util.ATIS1000080_v004_Date,
+		EffectiveDate: util.ATIS1000080_v003_Date,
 		Lint:          NewCaAuthorityKeyIdentifier,
 	})
 }

--- a/v3/lints/shaken/lint_sti_ca_certificate_policies.go
+++ b/v3/lints/shaken/lint_sti_ca_certificate_policies.go
@@ -12,7 +12,7 @@ func init() {
 	lint.RegisterLint(&lint.Lint{
 		Name:          "e_sti_ca_certificate_policies",
 		Description:   "STI Intermediate certificates shall include a Certificate Policies extension containing a single OID value that identifies the SHAKEN Certificate Policy established by the STI-PA",
-		Citation:      ATIS1000080_STI_Citation,
+		Citation:      ATIS1000080v004_STI_Citation,
 		Source:        lint.ATIS1000080,
 		EffectiveDate: util.ATIS1000080_v004_Date,
 		Lint:          NewCaCertificatePolicies,
@@ -31,7 +31,7 @@ func (*caCertificatePolicies) CheckApplies(c *x509.Certificate) bool {
 // Execute implements lint.LintInterface
 func (*caCertificatePolicies) Execute(c *x509.Certificate) *lint.LintResult {
 	if len(c.PolicyIdentifiers) == 1 {
-		if c.NotBefore.After(util.CPv1_3_Leaf_Date) && !c.PolicyIdentifiers[0].Equal(util.ShakenCPv1_3OID) {
+		if c.NotBefore.After(util.UnitedStatesSHAKENCP_Leaf_Date) && !c.PolicyIdentifiers[0].Equal(util.ShakenUnitedStatesSHAKENCPOID) {
 			return &lint.LintResult{
 				Status:  lint.Error,
 				Details: "STI certificate shall contain '2.16.840.1.114569.1.1.3' policy",

--- a/v3/lints/shaken/lint_sti_ca_certificate_policy_critical.go
+++ b/v3/lints/shaken/lint_sti_ca_certificate_policy_critical.go
@@ -12,7 +12,7 @@ func init() {
 	lint.RegisterLint(&lint.Lint{
 		Name:          "n_sti_ca_certificate_policy_critical",
 		Description:   "STI certificates should contain a CertificatePolicies extension marked uncritical",
-		Citation:      ATIS1000080_STI_Citation,
+		Citation:      ATIS1000080v004_STI_Citation,
 		Source:        lint.ATIS1000080,
 		EffectiveDate: util.ATIS1000080_v004_Date,
 		Lint:          NewCaCertificatePolicyCritical,

--- a/v3/lints/shaken/lint_sti_ca_crl_distribution.go
+++ b/v3/lints/shaken/lint_sti_ca_crl_distribution.go
@@ -12,7 +12,7 @@ func init() {
 	lint.RegisterLint(&lint.Lint{
 		Name:          "e_sti_ca_crl_distribution",
 		Description:   "STI intermediate certificates shall contain a CRL Distribution Points extension containing a single DistributionPoint entry",
-		Citation:      ATIS1000080_STI_Citation,
+		Citation:      ATIS1000080v004_STI_Citation,
 		Source:        lint.ATIS1000080,
 		EffectiveDate: util.ATIS1000080_v004_Date,
 		Lint:          NewCaCrlDistribution,

--- a/v3/lints/shaken/lint_sti_ca_extension_unknown.go
+++ b/v3/lints/shaken/lint_sti_ca_extension_unknown.go
@@ -12,7 +12,7 @@ func init() {
 	lint.RegisterLint(&lint.Lint{
 		Name:          "e_sti_ca_extension_unknown",
 		Description:   "STI certificate shall not include extensions that are not specified",
-		Citation:      ATIS1000080_STI_Citation,
+		Citation:      ATIS1000080v004_STI_Citation,
 		Source:        lint.ATIS1000080,
 		EffectiveDate: util.ATIS1000080_v004_Date,
 		Lint:          NewCaExtensionUnknown,

--- a/v3/lints/shaken/lint_sti_ca_issuer_dn.go
+++ b/v3/lints/shaken/lint_sti_ca_issuer_dn.go
@@ -12,9 +12,9 @@ func init() {
 	lint.RegisterLint(&lint.Lint{
 		Name:          "e_sti_ca_issuer_dn",
 		Description:   subject_details,
-		Citation:      ATIS1000080_STI_Citation,
+		Citation:      ATIS1000080v003_STI_Citation,
 		Source:        lint.ATIS1000080,
-		EffectiveDate: util.ATIS1000080_v004_Leaf_Date,
+		EffectiveDate: util.ATIS1000080_v003_Leaf_Date,
 		Lint:          NewCaIssuerDn,
 	})
 }

--- a/v3/lints/shaken/lint_sti_ca_key_usage.go
+++ b/v3/lints/shaken/lint_sti_ca_key_usage.go
@@ -12,9 +12,9 @@ func init() {
 	lint.RegisterLint(&lint.Lint{
 		Name:          "e_sti_ca_key_usage",
 		Description:   "STI certificates shall contain a Key Usage extension marked as critical. For root and intermediate certificates, the Key Usage extension shall contain the key usage value keyCertSign (5), and may contain the key usage values digitalSignature (0) and/or cRLSign (6)",
-		Citation:      ATIS1000080_STI_Citation,
+		Citation:      ATIS1000080v003_STI_Citation,
 		Source:        lint.ATIS1000080,
-		EffectiveDate: util.ATIS1000080_v004_Date,
+		EffectiveDate: util.ATIS1000080_v003_Date,
 		Lint:          NewCaKeyUsage,
 	})
 }

--- a/v3/lints/shaken/lint_sti_ca_serial_number.go
+++ b/v3/lints/shaken/lint_sti_ca_serial_number.go
@@ -12,7 +12,7 @@ func init() {
 	lint.RegisterLint(&lint.Lint{
 		Name:          "e_sti_ca_serial_number",
 		Description:   "STI certificates shall include a Serial Number field containing an integer greater than zero. The serial number shall contain at least 64 bits of output from a Cryptographically Secure PseudoRandom Number Generator (CSPRNG)",
-		Citation:      ATIS1000080_STI_Citation,
+		Citation:      ATIS1000080v004_STI_Citation,
 		Source:        lint.ATIS1000080,
 		EffectiveDate: util.ATIS1000080_v004_Date,
 		Lint:          NewCaSerialNumber,

--- a/v3/lints/shaken/lint_sti_ca_signature_algorithm.go
+++ b/v3/lints/shaken/lint_sti_ca_signature_algorithm.go
@@ -12,9 +12,9 @@ func init() {
 	lint.RegisterLint(&lint.Lint{
 		Name:          "e_sti_ca_signature_algorithm",
 		Description:   signatureAlgorithm_details,
-		Citation:      ATIS1000080_STI_Citation,
+		Citation:      ATIS1000080v003_STI_Citation,
 		Source:        lint.ATIS1000080,
-		EffectiveDate: util.ATIS1000080_v004_Date,
+		EffectiveDate: util.ATIS1000080_v003_Date,
 		Lint:          NewCaSignatureAlgorithm,
 	})
 }

--- a/v3/lints/shaken/lint_sti_ca_subject.go
+++ b/v3/lints/shaken/lint_sti_ca_subject.go
@@ -12,9 +12,9 @@ func init() {
 	lint.RegisterLint(&lint.Lint{
 		Name:          "e_sti_ca_subject",
 		Description:   subject_details,
-		Citation:      ATIS1000080_STI_Citation,
+		Citation:      ATIS1000080v003_STI_Citation,
 		Source:        lint.ATIS1000080,
-		EffectiveDate: util.ATIS1000080_v004_Date,
+		EffectiveDate: util.ATIS1000080_v003_Date,
 		Lint:          NewCaSubject,
 	})
 }

--- a/v3/lints/shaken/lint_sti_ca_subject_cn.go
+++ b/v3/lints/shaken/lint_sti_ca_subject_cn.go
@@ -14,7 +14,7 @@ func init() {
 	lint.RegisterLint(&lint.Lint{
 		Name:          "e_sti_ca_subject_cn",
 		Description:   "For non-End-Entity CA certificates, the Common Name attribute shall include the text string \"SHAKEN\" and also indicate whether the certificate is a root or intermediate certificate",
-		Citation:      ATIS1000080_STI_Citation,
+		Citation:      ATIS1000080v004_STI_Citation,
 		Source:        lint.ATIS1000080,
 		EffectiveDate: util.ATIS1000080_v004_Date,
 		Lint:          NewCaSubjectCN,

--- a/v3/lints/shaken/lint_sti_ca_subject_key_identifier.go
+++ b/v3/lints/shaken/lint_sti_ca_subject_key_identifier.go
@@ -12,9 +12,9 @@ func init() {
 	lint.RegisterLint(&lint.Lint{
 		Name:          "e_sti_ca_subject_key_identifier",
 		Description:   subjectKeyIdentifier_details,
-		Citation:      ATIS1000080_STI_Citation,
+		Citation:      ATIS1000080v003_STI_Citation,
 		Source:        lint.ATIS1000080,
-		EffectiveDate: util.ATIS1000080_v004_Date,
+		EffectiveDate: util.ATIS1000080_v003_Date,
 		Lint:          NewCaSubjectKeyIdentifier,
 	})
 }

--- a/v3/lints/shaken/lint_sti_ca_subject_public_key.go
+++ b/v3/lints/shaken/lint_sti_ca_subject_public_key.go
@@ -12,9 +12,9 @@ func init() {
 	lint.RegisterLint(&lint.Lint{
 		Name:          "e_sti_ca_subject_public_key",
 		Description:   subjectPublicKey_details,
-		Citation:      ATIS1000080_STI_Citation,
+		Citation:      ATIS1000080v003_STI_Citation,
 		Source:        lint.ATIS1000080,
-		EffectiveDate: util.ATIS1000080_v004_Date,
+		EffectiveDate: util.ATIS1000080_v003_Date,
 		Lint:          NewCaSubjectPublicKey,
 	})
 }

--- a/v3/lints/shaken/lint_sti_ca_version.go
+++ b/v3/lints/shaken/lint_sti_ca_version.go
@@ -12,9 +12,9 @@ func init() {
 	lint.RegisterLint(&lint.Lint{
 		Name:          "e_sti_ca_version",
 		Description:   version_details,
-		Citation:      ATIS1000080_STI_Citation,
+		Citation:      ATIS1000080v003_STI_Citation,
 		Source:        lint.ATIS1000080,
-		EffectiveDate: util.ATIS1000080_v004_Date,
+		EffectiveDate: util.ATIS1000080_v003_Date,
 		Lint:          NewCaVersion,
 	})
 }

--- a/v3/lints/shaken/lint_sti_certificate_policies.go
+++ b/v3/lints/shaken/lint_sti_certificate_policies.go
@@ -12,9 +12,9 @@ func init() {
 	lint.RegisterLint(&lint.Lint{
 		Name:          "e_sti_certificate_policies",
 		Description:   "STI End-Entity certificates shall include a Certificate Policies extension containing a single OID value that identifies the SHAKEN Certificate Policy established by the STI-PA",
-		Citation:      ATIS1000080_STI_Citation,
+		Citation:      ATIS1000080v003_STI_Citation,
 		Source:        lint.ATIS1000080,
-		EffectiveDate: util.ATIS1000080_v004_Leaf_Date,
+		EffectiveDate: util.ATIS1000080_v003_Leaf_Date,
 		Lint:          NewCertificatePolicies,
 	})
 }
@@ -31,7 +31,7 @@ func (*certificatePolicies) CheckApplies(c *x509.Certificate) bool {
 // Execute implements lint.LintInterface
 func (*certificatePolicies) Execute(c *x509.Certificate) *lint.LintResult {
 	if len(c.PolicyIdentifiers) == 1 {
-		if c.NotBefore.After(util.CPv1_3_Leaf_Date) && !c.PolicyIdentifiers[0].Equal(util.ShakenCPv1_3OID) {
+		if c.NotBefore.After(util.UnitedStatesSHAKENCP_Leaf_Date) && !c.PolicyIdentifiers[0].Equal(util.ShakenUnitedStatesSHAKENCPOID) {
 			return &lint.LintResult{
 				Status:  lint.Error,
 				Details: "STI certificate shall contain '2.16.840.1.114569.1.1.3' policy",

--- a/v3/lints/shaken/lint_sti_certificate_policy_critical.go
+++ b/v3/lints/shaken/lint_sti_certificate_policy_critical.go
@@ -12,9 +12,9 @@ func init() {
 	lint.RegisterLint(&lint.Lint{
 		Name:          "n_sti_certificate_policy_critical",
 		Description:   "STI certificates should contain a CertificatePolicies extension marked uncritical",
-		Citation:      ATIS1000080_STI_Citation,
+		Citation:      ATIS1000080v003_STI_Citation,
 		Source:        lint.ATIS1000080,
-		EffectiveDate: util.ATIS1000080_v004_Leaf_Date,
+		EffectiveDate: util.ATIS1000080_v003_Leaf_Date,
 		Lint:          NewCertificatePolicyCritical,
 	})
 }

--- a/v3/lints/shaken/lint_sti_crl_distribution.go
+++ b/v3/lints/shaken/lint_sti_crl_distribution.go
@@ -15,9 +15,9 @@ func init() {
 	lint.RegisterLint(&lint.Lint{
 		Name:          "e_sti_crl_distribution",
 		Description:   "STI End-Entity certificates shall contain a CRL Distribution Points extension containing a single DistributionPoint entry",
-		Citation:      ATIS1000080_STI_Citation,
+		Citation:      ATIS1000080v003_STI_Citation,
 		Source:        lint.ATIS1000080,
-		EffectiveDate: util.ATIS1000080_v004_Leaf_Date,
+		EffectiveDate: util.ATIS1000080_v003_Leaf_Date,
 		Lint:          NewCrlDistribution,
 	})
 }

--- a/v3/lints/shaken/lint_sti_issuer_dn.go
+++ b/v3/lints/shaken/lint_sti_issuer_dn.go
@@ -12,9 +12,9 @@ func init() {
 	lint.RegisterLint(&lint.Lint{
 		Name:          "e_sti_issuer_dn",
 		Description:   subject_details,
-		Citation:      ATIS1000080_STI_Citation,
+		Citation:      ATIS1000080v003_STI_Citation,
 		Source:        lint.ATIS1000080,
-		EffectiveDate: util.ATIS1000080_v004_Leaf_Date,
+		EffectiveDate: util.ATIS1000080_v003_Leaf_Date,
 		Lint:          NewIssuerDn,
 	})
 }

--- a/v3/lints/shaken/lint_sti_key_usage.go
+++ b/v3/lints/shaken/lint_sti_key_usage.go
@@ -12,9 +12,9 @@ func init() {
 	lint.RegisterLint(&lint.Lint{
 		Name:          "e_sti_key_usage",
 		Description:   "STI certificates shall contain a Key Usage extension marked as critical. For End-Entity certificates, the Key Usage extension shall contain a single key usage value of digitalSignature (0).",
-		Citation:      ATIS1000080_STI_Citation,
+		Citation:      ATIS1000080v003_STI_Citation,
 		Source:        lint.ATIS1000080,
-		EffectiveDate: util.ATIS1000080_v004_Leaf_Date,
+		EffectiveDate: util.ATIS1000080_v003_Leaf_Date,
 		Lint:          NewKeyUsage,
 	})
 }

--- a/v3/lints/shaken/lint_sti_root_authority_key_identifier.go
+++ b/v3/lints/shaken/lint_sti_root_authority_key_identifier.go
@@ -24,9 +24,9 @@ func init() {
 		Description: "For root certificates that contain an Authority Key Identifier extension, " +
 			"the Authority Key Identifier shall contain a keyIdentifier field with a value that matches " +
 			"the Subject Key Identifier value of the same root certificate",
-		Citation:      ATIS1000080_STI_Citation,
+		Citation:      ATIS1000080v003_STI_Citation,
 		Source:        lint.ATIS1000080,
-		EffectiveDate: util.ATIS1000080_v004_Date,
+		EffectiveDate: util.ATIS1000080_v003_Date,
 		Lint:          NewRootAuthorityKeyIdentifier,
 	})
 }

--- a/v3/lints/shaken/lint_sti_root_certificate_policies.go
+++ b/v3/lints/shaken/lint_sti_root_certificate_policies.go
@@ -12,7 +12,7 @@ func init() {
 	lint.RegisterLint(&lint.Lint{
 		Name:          "e_sti_root_certificate_policies",
 		Description:   "STI Root certificates shall not contain a Certificate Policies extension",
-		Citation:      ATIS1000080_STI_Citation,
+		Citation:      ATIS1000080v004_STI_Citation,
 		Source:        lint.ATIS1000080,
 		EffectiveDate: util.ATIS1000080_v004_Date,
 		Lint:          NewRootCertificatePolicies,

--- a/v3/lints/shaken/lint_sti_root_extension_unknown.go
+++ b/v3/lints/shaken/lint_sti_root_extension_unknown.go
@@ -12,7 +12,7 @@ func init() {
 	lint.RegisterLint(&lint.Lint{
 		Name:          "e_sti_root_extension_unknown",
 		Description:   "STI certificate shall not include extensions that are not specified",
-		Citation:      ATIS1000080_STI_Citation,
+		Citation:      ATIS1000080v004_STI_Citation,
 		Source:        lint.ATIS1000080,
 		EffectiveDate: util.ATIS1000080_v004_Date,
 		Lint:          NewRootExtensionUnknown,

--- a/v3/lints/shaken/lint_sti_serial_number.go
+++ b/v3/lints/shaken/lint_sti_serial_number.go
@@ -16,7 +16,7 @@ func init() {
 	lint.RegisterLint(&lint.Lint{
 		Name:          "e_sti_serial_number",
 		Description:   "STI certificates shall include a Serial Number field containing an integer greater than zero. The serial number shall contain at least 64 bits of output from a Cryptographically Secure PseudoRandom Number Generator (CSPRNG)",
-		Citation:      ATIS1000080_STI_Citation,
+		Citation:      ATIS1000080v004_STI_Citation,
 		Source:        lint.ATIS1000080,
 		EffectiveDate: util.ATIS1000080_v004_Leaf_Date,
 		Lint:          NewSerialNumber,

--- a/v3/lints/shaken/lint_sti_signature_algorithm.go
+++ b/v3/lints/shaken/lint_sti_signature_algorithm.go
@@ -16,7 +16,7 @@ func init() {
 	lint.RegisterLint(&lint.Lint{
 		Name:          "e_sti_signature_algorithm",
 		Description:   signatureAlgorithm_details,
-		Citation:      ATIS1000080_STI_Citation,
+		Citation:      ATIS1000080v004_STI_Citation,
 		Source:        lint.ATIS1000080,
 		EffectiveDate: util.ATIS1000080_v004_Leaf_Date,
 		Lint:          NewSignatureAlgorithm,

--- a/v3/lints/shaken/lint_sti_subject.go
+++ b/v3/lints/shaken/lint_sti_subject.go
@@ -14,9 +14,9 @@ func init() {
 	lint.RegisterLint(&lint.Lint{
 		Name:          "e_sti_subject",
 		Description:   subject_details,
-		Citation:      ATIS1000080_STI_Citation,
+		Citation:      ATIS1000080v003_STI_Citation,
 		Source:        lint.ATIS1000080,
-		EffectiveDate: util.ATIS1000080_v004_Leaf_Date,
+		EffectiveDate: util.ATIS1000080_v003_Leaf_Date,
 		Lint:          NewSubject,
 	})
 }

--- a/v3/lints/shaken/lint_sti_subject_cn.go
+++ b/v3/lints/shaken/lint_sti_subject_cn.go
@@ -15,7 +15,7 @@ func init() {
 	lint.RegisterLint(&lint.Lint{
 		Name:          "e_sti_subject_cn",
 		Description:   "The Common Name attribute of an End-Entity certificate shall contain the text string “SHAKEN”, followed by a single space, followed by the SPC value identified in the TNAuthList of the End-Entity certificate",
-		Citation:      ATIS1000080_STI_Citation,
+		Citation:      ATIS1000080v004_STI_Citation,
 		Source:        lint.ATIS1000080,
 		EffectiveDate: util.ATIS1000080_v004_Leaf_Date,
 		Lint:          NewSubjectCN,

--- a/v3/lints/shaken/lint_sti_subject_key_identifier.go
+++ b/v3/lints/shaken/lint_sti_subject_key_identifier.go
@@ -16,9 +16,9 @@ func init() {
 	lint.RegisterLint(&lint.Lint{
 		Name:          "e_sti_subject_key_identifier",
 		Description:   subjectKeyIdentifier_details,
-		Citation:      ATIS1000080_STI_Citation,
+		Citation:      ATIS1000080v003_STI_Citation,
 		Source:        lint.ATIS1000080,
-		EffectiveDate: util.ATIS1000080_v004_Leaf_Date,
+		EffectiveDate: util.ATIS1000080_v003_Leaf_Date,
 		Lint:          NewSubjectKeyIdentifier,
 	})
 }

--- a/v3/lints/shaken/lint_sti_subject_public_key.go
+++ b/v3/lints/shaken/lint_sti_subject_public_key.go
@@ -16,9 +16,9 @@ func init() {
 	lint.RegisterLint(&lint.Lint{
 		Name:          "e_sti_subject_public_key",
 		Description:   subjectPublicKey_details,
-		Citation:      ATIS1000080_STI_Citation,
+		Citation:      ATIS1000080v003_STI_Citation,
 		Source:        lint.ATIS1000080,
-		EffectiveDate: util.ATIS1000080_v004_Leaf_Date,
+		EffectiveDate: util.ATIS1000080_v003_Leaf_Date,
 		Lint:          NewSubjectPublicKey,
 	})
 }

--- a/v3/lints/shaken/lint_sti_tn_auth_list.go
+++ b/v3/lints/shaken/lint_sti_tn_auth_list.go
@@ -12,9 +12,9 @@ func init() {
 	lint.RegisterLint(&lint.Lint{
 		Name:          "e_sti_tn_auth_list",
 		Description:   "STI End-Entity certificates shall contain a TNAuthList extension as specified in RFC 8226. The TNAuthList shall contain a single SPC value",
-		Citation:      ATIS1000080_STI_Citation,
+		Citation:      ATIS1000080v003_STI_Citation,
 		Source:        lint.ATIS1000080,
-		EffectiveDate: util.ATIS1000080_v004_Leaf_Date,
+		EffectiveDate: util.ATIS1000080_v003_Leaf_Date,
 		Lint:          NewTnAuthList,
 	})
 }

--- a/v3/lints/shaken/lint_sti_version.go
+++ b/v3/lints/shaken/lint_sti_version.go
@@ -16,9 +16,9 @@ func init() {
 	lint.RegisterLint(&lint.Lint{
 		Name:          "e_sti_version",
 		Description:   version_details,
-		Citation:      ATIS1000080_STI_Citation,
+		Citation:      ATIS1000080v003_STI_Citation,
 		Source:        lint.ATIS1000080,
-		EffectiveDate: util.ATIS1000080_v004_Leaf_Date,
+		EffectiveDate: util.ATIS1000080_v003_Leaf_Date,
 		Lint:          NewVersion,
 	})
 }

--- a/v3/util/oid.go
+++ b/v3/util/oid.go
@@ -96,7 +96,7 @@ var (
 	IdEtsiQcsQctWeb            = asn1.ObjectIdentifier{0, 4, 0, 1862, 1, 6, 3}
 	// SHAKEN policies
 	ShakenCPv1_1OID = asn1.ObjectIdentifier{2, 16, 840, 1, 114569, 1, 1, 1}
-	ShakenCPv1_3OID = asn1.ObjectIdentifier{2, 16, 840, 1, 114569, 1, 1, 3}
+	ShakenUnitedStatesSHAKENCPOID = asn1.ObjectIdentifier{2, 16, 840, 1, 114569, 1, 1, 3}
 )
 
 const (

--- a/v3/util/time.go
+++ b/v3/util/time.go
@@ -72,18 +72,23 @@ var (
 	CABFBRs_1_8_0_Date                               = time.Date(2021, time.August, 25, 0, 0, 0, 0, time.UTC)
 	NoReservedDomainLabelsDate                       = time.Date(2021, time.October, 1, 0, 0, 0, 0, time.UTC)
 	CABFBRs_OU_Prohibited_Date                       = time.Date(2022, time.September, 1, 0, 0, 0, 0, time.UTC)
+	ATIS1000080_v003_Date                            = time.Date(2020, time.September, 4, 0, 0, 0, 0, time.UTC)
+	// ATIS-1000080.v003 was published on Friday, 4 September 2020.
+	// If we apply the same rule of 90 days after approval for CAs to be conformant with new versions as is applied to CP->CPS
+	// changes this means any changes would be required for certificates issued on or after Thursday, December 3, 2020.
+	ATIS1000080_v003_Leaf_Date = time.Date(2020, time.December, 3, 0, 0, 0, 0, time.UTC)
 	ATIS1000080_v004_Date                            = time.Date(2021, time.October, 18, 0, 0, 0, 0, time.UTC)
 	// ATIS-1000080.v004 was published on Monday, 18 October 2021.
 	// If we apply the same rule of 90 days after approval for CAs to be conformant with new versions as is applied to CP->CPS
 	// changes this means any changes would be required for certificates issued on or after Sunday, January 16, 2022.
 	ATIS1000080_v004_Leaf_Date = time.Date(2022, time.January, 16, 0, 0, 0, 0, time.UTC)
-	CPv1_3_Date                = time.Date(2022, time.August, 18, 0, 0, 0, 0, time.UTC)
+	UnitedStatesSHAKENCP_Date                = time.Date(2022, time.August, 18, 0, 0, 0, 0, time.UTC)
 	// CPS 1.3 was approved on August 18, 2021.
 	// If we assume that CAs CPSs were submitted for approval on the 45th day, the CPS was approved within 10 days
 	// and the CA has 90 days to become conformant then certificates issued on or after "Monday, January 10, 2022"
 	// should be evaluated against the new rules.
 	// January 10, 2022
-	CPv1_3_Leaf_Date = time.Date(2022, time.January, 10, 0, 0, 0, 0, time.UTC)
+	UnitedStatesSHAKENCP_Leaf_Date = time.Date(2022, time.January, 10, 0, 0, 0, 0, time.UTC)
 )
 
 var (


### PR DESCRIPTION
There are multiple CPs: US, Canada, and France; so the CP was renamed to include the country.

For consistency with the rest of the lint sources, the version was removed from the CP and ATIS-1000080.

ATIS-1000080v3 support was added.